### PR TITLE
feat:人物物体の検出と切り抜きの実装

### DIFF
--- a/module/k22025.py
+++ b/module/k22025.py
@@ -1,0 +1,14 @@
+from ultralytics import YOLO
+import cv2
+
+# モデル読み込み
+model = YOLO("yolov8x-seg.pt")
+
+# 入力画像
+results = model(
+    "./img.jpg",
+    project="./edit",
+    save=True,
+    show=True,
+    save_crop=True,
+)

--- a/module/k22025.py
+++ b/module/k22025.py
@@ -20,14 +20,17 @@ class k22025(PostProcessing):
         # 入力画像
         results = model(
             image,
-            project="./edit",
+            project="/Users/k22025kk/work/oop2/lecture13/kadai12/img/edit",
             save=True,
             show=True,
             save_crop=True,
         )
+        # ウィンドウが閉じるのを待つ
+        cv2.waitKey(0)
+        cv2.destroyAllWindows()
 
 
 if __name__ == "__main__":
     k22025 = k22025()
-    k22025.sampleFunc()
-    k22025.exportImage("sample.png")
+    k22025.modelFunc()
+    # k22025.exportImage("sample.png")

--- a/module/k22025.py
+++ b/module/k22025.py
@@ -1,14 +1,33 @@
 from ultralytics import YOLO
 import cv2
+import os
+from postProcessing import PostProcessing
 
-# モデル読み込み
-model = YOLO("yolov8x-seg.pt")
 
-# 入力画像
-results = model(
-    "./img.jpg",
-    project="./edit",
-    save=True,
-    show=True,
-    save_crop=True,
-)
+class k22025(PostProcessing):
+    # これは必須
+    def __init__(self):
+        super().__init__()
+        pass
+
+    def modelFunc(self):
+        # 画像の読み込みは基本この関数を使う
+        image = self.getEditImage()
+
+        # モデル読み込み
+        model = YOLO("yolov8x-seg.pt")
+
+        # 入力画像
+        results = model(
+            image,
+            project="./edit",
+            save=True,
+            show=True,
+            save_crop=True,
+        )
+
+
+if __name__ == "__main__":
+    k22025 = k22025()
+    k22025.sampleFunc()
+    k22025.exportImage("sample.png")


### PR DESCRIPTION
概要
人物物体の検出と切り抜きの実装

変更内容
/img/editから画像の読み込みを追加
学習データの読み読みを追加
読み込まれた画像から人や物体を検出する機能を追加
検出されたものを切り抜き/img/editに保存する機能を追加

期待している動作
トップページ：実行すると/img/editにある画像を読み込み人、物体を検知。その後検知した範囲を示した画像と検知したものを切り抜いた画像が/img/editの中に保存される。この際predictフォルダが生成される。predictの中に検知した範囲を示した画像と検知したものを切り抜いた画像が入っている。

影響範囲
k222025.py + imgフォルダ

動作要件
YOLOv8を使用してるためPython>=3.8,PyTorch>=1.8.である必要があります。
学習データもインストールする必要がありますがデータが存在しない場合、実行時に自動でインストールされます。
もしされない場合はyolov8x-seg.ptをhttps://docs.ultralytics.com/ja/tasks/segment/から導入してください。

補足
predictフォルダが/img/editの中に作成されます