### PR TITLE
feat: 画像の大きさをリサイズ表示

### DIFF
--- a/GUI/components/IshikawaLayoutTopPgae1.py
+++ b/GUI/components/IshikawaLayoutTopPgae1.py
@@ -32,8 +32,11 @@ class TopPage(QWidget):
 
         #画像の表示関数
         def showImages(name):
+            beforeimg = QImage(name)
+            afterimg = beforeimg.scaled(300,500,QtCore.Qt.AspectRatioMode.KeepAspectRatio)
+
             image = QLabel()
-            image.setPixmap(QPixmap(name))
+            image.setPixmap(QPixmap.fromImage(afterimg))
             layout_image = QHBoxLayout()
             layout_image.addWidget(image)
             return layout_image
@@ -61,7 +64,7 @@ class TopPage(QWidget):
 
 
 app = QApplication(sys.argv)
-app.setStyleSheet('QLabel{border: 1px solid black;}')
+# app.setStyleSheet('QLabel{border: 1px solid black;}')
 main_widget = TopPage()
 main_widget.show()
 app.exec()


### PR DESCRIPTION
# 概要
<!-- タイトルと同様で構いません -->
画像の大きさをリサイズ表示

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
IshikawaLayoutTopPgae1.pyのshowImages関数を修正


# 期待している動作
<!-- 正常に動作した時に期待される動作をここに書いてください(実現したい動作ではないので注意) -->
<!-- 例：sample.pyを実行すると◯◯フォルダに画像が出力される、など -->
img/edit 以下の画像がリサイズされたうえで表示される

# 影響範囲
<!-- dataフォルダに◯◯というxmlファイルを追加した、など -->

# 動作要件
<!-- 新しくライブラリをインポートした時はここに書くこと -->
<!-- 特定の画像で動作を確認した場合はここに載せる -->
img/edit以下に何らかの画像があること

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
ビューの枠線を削除しました。
