### PR TITLE
feat:編集ページのレイアウト

### DIFF
--- a/GUI/components/imageWindow.py
+++ b/GUI/components/imageWindow.py
@@ -1,12 +1,13 @@
 import sys
 from PySide6.QtWidgets import *
+from PySide6.QtCore import Qt
 from PySide6 import QtGui,QtCore
 import os
 
 # 画像を表示するウィンドウのクラス
 class ImageWindow(QLabel):
     # 画像のサイズはデフォルトで800x600
-    def __init__(self,parent:QWidget | None=None,width:int=800,height:int=600):
+    def __init__(self,parent: QDockWidget| None=None,width:int=800,height:int=600):
         super(ImageWindow, self).__init__(parent)
         self.imagePath=None
         self.width=width
@@ -36,12 +37,18 @@ class ImageWindow(QLabel):
             # print("画像が見つかりませんでした")
             self.setText("画像が見つかりませんでした")
 
-class DebugWindow(QWidget):
+class DebugWindow(QMainWindow):
     def __init__(self, parent=None):
         super(DebugWindow, self).__init__(parent)
         self.setWindowTitle("デバッグ用ウィンドウ")
         self.resize(800, 600)
-        self.imageWindow=ImageWindow(parent=self)
+        #self.imageWindow=ImageWindow(parent=self)
+        self.imageDock = QDockWidget("canvas",self)
+        self.imageWindow = QWidget()
+        ImageWindow(self.imageWindow)
+        self.imageDock.setWidget(self.imageWindow)
+
+        self.addDockWidget(Qt.RightDockWidgetArea, self.imageDock)
 
 if __name__ == '__main__':
     app = QApplication(sys.argv)

--- a/GUI/components/scroll.py
+++ b/GUI/components/scroll.py
@@ -3,7 +3,7 @@ import os
 from PySide6.QtWidgets import *
 from PySide6.QtGui import QPixmap
 from PySide6 import QtGui, QtCore
-from imageWindow import ImageWindow
+from .imageWindow import ImageWindow
 
 class ScrollArea(QScrollArea):
     def __init__(self, parent=None):

--- a/GUI/components/toolBar.py
+++ b/GUI/components/toolBar.py
@@ -8,7 +8,7 @@ from PySide6.QtWidgets import QWidget
 
 #ツールバーのGUI
 class ToolBar():
-    def __init__(self,parent:QWidget):
+    def __init__(self,parent:QDockWidget):
         
         layout = QVBoxLayout()
 
@@ -59,12 +59,17 @@ class ToolBar():
 
         parent.setLayout(layout)
 
-class DebugWindow(QWidget):
+class DebugWindow(QMainWindow):
     def __init__(self, parent=None):
         super(DebugWindow, self).__init__(parent)
         self.setWindowTitle("デバッグ用ウィンドウ")
         self.resize(100, 500)
-        self.toolBar=ToolBar(self)
+        self.toolDock = QDockWidget("aaa",self)
+        self.toolBar = QWidget()
+        ToolBar(self.toolBar)
+        self.toolDock.setWidget(self.toolBar)
+
+        self.addDockWidget(Qt.LeftDockWidgetArea, self.toolDock)
         
     
 

--- a/GUI/editPage.py
+++ b/GUI/editPage.py
@@ -2,52 +2,48 @@
 import sys
 from PySide6.QtWidgets import *
 from PySide6 import QtGui,QtCore
+from PySide6.QtCore import Qt
+from components.toolBar import ToolBar
+from components.imageWindow import ImageWindow
+from components.scroll import ScrollArea
 
-class EditPage(QWidget):
+class EditPage(QMainWindow):
     def __init__(self):
         super().__init__()
         self.resize(1000,600)
-        #ラベルで上（メニューバー）、右下（キャンバス）
-        #メニューバー
-        self.labelMenu = QLabel(self)
-        self.labelStyle = """QLabel {
-            background-color: #FFAA00;  /* 背景色 */
-        }"""
-        self.labelMenu.setText("メニューバーが入ります")
-        # 見た目の設定をラベルに反映させる
-        self.labelMenu.setStyleSheet(self.labelStyle)
+
+        # 上部のメッセージエリア
+        messageArea = QLabel("上部のメッセージエリア")
+        messageArea.setStyleSheet("background-color: lightgray;")
+        messageArea.setAlignment(Qt.AlignCenter)
 
         #ツールバー
-        self.labelTool = QLabel(self)
-        self.labelStyle = """QLabel {
-            background-color: #FF0000;  /* 背景色 */
-        }"""
-        self.labelTool.setText("ツールバーが入ります")
-        # 見た目の設定をラベルに反映させる
-        self.labelTool.setStyleSheet(self.labelStyle)
+        self.toolDock = QDockWidget("tool",self)
+        self.toolBar = QWidget()
+        ToolBar(self.toolBar)
+        self.toolDock.setWidget(self.toolBar)
+        self.addDockWidget(Qt.LeftDockWidgetArea, self.toolDock)
 
         #キャンバス
-        self.labelCanvas = QLabel(self)
-        self.labelStyle = """QLabel {
-            background-color: #FFFFFF;  /* 背景色 */
-        }"""
-        self.labelCanvas.setText("キャンバスが入ります")
-        # 見た目の設定をラベルに反映させる
-        self.labelCanvas.setStyleSheet(self.labelStyle)
+        self.imageWindow = ImageWindow()  # キャンバスを作成
+        self.setCentralWidget(self.imageWindow) # キャンバスをセントラルウィジェットに設定
+        self.scrollArea = ScrollArea(self)  # スクロールエリアを作成
+        self.layout = QVBoxLayout(self) # レイアウトを作成
+        self.layout.addWidget(self.scrollArea)  # レイアウトにスクロールエリアを追加
+        self.imageWindow = ImageWindow(self,width=4000,height=3000)    # スクロールエリアに追加するウィジェットを作成
+        self.scrollArea.addWidget(self.imageWindow) # スクロールエリアにウィジェットを追加
 
-        #メニューバーを垂直方向に並べる
-        layoutQV = QVBoxLayout()
-        layoutQV.addWidget(self.labelMenu)
-        #ツールバーとキャンバスを水平方向に並べる
-        layoutQH = QHBoxLayout()
-        layoutQH.addWidget(self.labelTool,1)
-        layoutQH.addWidget(self.labelCanvas,5)
-        #レイアウト同士を組み合わせる
-        parentLayout = QVBoxLayout()
-        parentLayout.addLayout(layoutQV,1)
-        parentLayout.addLayout(layoutQH,5)
+         # メインレイアウト
+        layoutMain = QVBoxLayout()
+        layoutMain.addWidget(messageArea,1)
+        layoutMain.addWidget(self.scrollArea,4)
+        
 
-        self.setLayout(parentLayout)  
+        # メインウィジェットにメインレイアウトを設定
+        widgetMain = QWidget()
+        widgetMain.setLayout(layoutMain)
+        self.setCentralWidget(widgetMain)
+        
 
 
 if __name__ == '__main__':


### PR DESCRIPTION


# 概要
編集ページのレイアウト

# 変更内容
ツールバー、キャンバス、メッセージエリアの追加

# 期待している動作
起動するとウィンドウの左側にツールバー、右上にメッセージエリア右下にキャンバス
ツールバーはウィンドウの上下左右に移動可能
キャンバスはimgフォルダのedit内に入っている画像が表示され、スクロールができる

# 影響範囲


# 動作要件


# 補足
ツールバーの比率に関しては実装できていません。厳しいかもしれないです