### PR TITLE
feat:人物物体の検出と切り抜きのリサイズ機能と修正

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/module/k22025.py
+++ b/module/k22025.py
@@ -21,7 +21,7 @@ class k22025(PostProcessing):
         resized_image = cv2.resize(image, (new_width, new_height))
 
         # リサイズ後の画像を保存
-        self.saveImage(resized_image)
+        # self.saveImage(resized_image)
 
         # ウィンドウに表示する場合
         # cv2.imshow("Resized Image", resized_image)
@@ -31,7 +31,7 @@ class k22025(PostProcessing):
     def modelFunc(self):
         # 画像の読み込みは基本この関数を使う
         image = self.getEditImage()
-        self.resize_image(image)
+        # self.resize_image(image)
 
         # モデル読み込み
         model = YOLO("./data/yolov8x-seg.pt")

--- a/module/k22025.py
+++ b/module/k22025.py
@@ -10,9 +10,9 @@ class k22025(PostProcessing):
         super().__init__()
         pass
 
-    def resize_image(input_path):
+    def resize_image(self,image):
         # 画像を読み込む
-        image = cv2.imread(input_path)
+        
 
         new_width = 800
         new_height = 600
@@ -21,7 +21,7 @@ class k22025(PostProcessing):
         resized_image = cv2.resize(image, (new_width, new_height))
 
         # リサイズ後の画像を保存
-        cv2.imwrite(image, resized_image)
+        self.saveImage(resized_image)
 
         # ウィンドウに表示する場合
         # cv2.imshow("Resized Image", resized_image)
@@ -34,14 +34,14 @@ class k22025(PostProcessing):
         self.resize_image(image)
 
         # モデル読み込み
-        model = YOLO("yolov8x-seg.pt")
+        model = YOLO("./data/yolov8x-seg.pt")
 
         # 入力画像
         results = model(
             image,
-            project=".img/tmp",
+            project="./img/tmp",
             save=True,
-            show=True,
+            show=False,
             save_crop=True,
         )
         # ウィンドウが閉じるのを待つ

--- a/module/k22025.py
+++ b/module/k22025.py
@@ -10,9 +10,28 @@ class k22025(PostProcessing):
         super().__init__()
         pass
 
+    def resize_image(input_path):
+        # 画像を読み込む
+        image = cv2.imread(input_path)
+
+        new_width = 800
+        new_height = 600
+
+        # リサイズ
+        resized_image = cv2.resize(image, (new_width, new_height))
+
+        # リサイズ後の画像を保存
+        cv2.imwrite(image, resized_image)
+
+        # ウィンドウに表示する場合
+        # cv2.imshow("Resized Image", resized_image)
+        # cv2.waitKey(0)
+        # cv2.destroyAllWindows()
+
     def modelFunc(self):
         # 画像の読み込みは基本この関数を使う
         image = self.getEditImage()
+        self.resize_image(image)
 
         # モデル読み込み
         model = YOLO("yolov8x-seg.pt")
@@ -20,13 +39,14 @@ class k22025(PostProcessing):
         # 入力画像
         results = model(
             image,
-            project="/Users/k22025kk/work/oop2/lecture13/kadai12/img/edit",
+            project=".img/tmp",
             save=True,
             show=True,
             save_crop=True,
         )
         # ウィンドウが閉じるのを待つ
-        cv2.waitKey(0)
+        # デバッグ用
+        # cv2.waitKey(0)
         cv2.destroyAllWindows()
 
 


### PR DESCRIPTION
概要
入力された画像を800×600にする機能追加

変更内容
読み込まれた画像を800×600にする関数を追加
検出されたものを切り抜き.img/tmpに保存するように変更

期待している動作
トップページ：実行すると/img/editにある画像を読み込み800×600に画像をリサイズした後人、物体を検知。その後検知した範囲を示した画像と検知したものを切り抜いた画像が/img/tmpの中に保存される。この際predictフォルダが生成される。predictの中に検知した範囲を示した画像と検知したものを切り抜いた画像が入っている。

影響範囲
k222025.py + imgフォルダ

動作要件
YOLOv8の学習ファイルがサイズが大きいたプッシュができなかった
そのため今回のプッシュではdataフォルダにyolov8x-seg.ptを配置できていない

補足
predictフォルダが/img/editの中に作成されます

大変遅くなってしまい申し訳ございません